### PR TITLE
Update Istio Properties

### DIFF
--- a/microservice-ecommerce-store-istio-deployment.jdl
+++ b/microservice-ecommerce-store-istio-deployment.jdl
@@ -224,8 +224,7 @@ deployment {
   appsFolders [store, invoice, notification, product]
   dockerRepositoryName "@Replace With Your Docker repo name@"
   serviceDiscoveryType no
-  istio autoInjection
-  istioRoute true
+  istio true
   kubernetesServiceType Ingress
   kubernetesNamespace jhipster
   ingressDomain "@Replace with your Istio IngressGateway's external IP@.nip.io"


### PR DESCRIPTION
This updates the Istio properties so that the jdl file will not fail. Notice that `istioRoute` has been removed as per below commit and the `istio` property takes a boolean. 

Related to https://github.com/jhipster/generator-jhipster/pull/9365/commits/de606c454292e2526dff2bfe5fa02f8cd81f4ad5